### PR TITLE
New enhancement to prevent alerting on Intruder.IO scans

### DIFF
--- a/elastalert_modules/drop_intruder_ip.py
+++ b/elastalert_modules/drop_intruder_ip.py
@@ -22,5 +22,8 @@ class DropIntruderIOIP(BaseEnhancement):
         ]
 
         for range in ranges:
-            if ipaddress.ip_address(match["source"]["ip"]) in ipaddress.ip_network(range):
-                raise DropMatchException()
+            try:
+                if ipaddress.ip_address(match["source"]["ip"]) in ipaddress.ip_network(range):
+                    raise DropMatchException()
+            except Exception as e:
+                util.elastalert_logger.error(e)

--- a/elastalert_modules/drop_intruder_ip.py
+++ b/elastalert_modules/drop_intruder_ip.py
@@ -8,13 +8,6 @@ class DropIntruderIOIP(BaseEnhancement):
     # This enhancement ensures we don't alert on Intruder.IO IP's
     # which frequently scan our Infra.
     def process(self, match):
-        whitelisted = self.generate_trusted_ips()
-        
-        if match["source"]["ip"] in whitelisted:
-            raise DropMatchException()
-
-    def generate_trusted_ips(self):
-        all_ips = ["139.162.214.111"]
         ranges = [
             "35.177.219.0/26",
             "3.9.159.128/25",
@@ -25,9 +18,9 @@ class DropIntruderIOIP(BaseEnhancement):
             "3.124.123.128/25",
             "3.67.7.128/25",
             "203.12.218.0/24",
+            "139.162.214.111/32"
         ]
 
         for range in ranges:
-            expanded = [str(ip) for ip in ipaddress.IPv4Address(range)]
-            all_ips.extend(expanded)
-        return all_ips
+            if ipaddress.ip_address(match["source"]["ip"]) in ipaddress.ip_network(range):
+                raise DropMatchException()

--- a/elastalert_modules/drop_intruder_ip.py
+++ b/elastalert_modules/drop_intruder_ip.py
@@ -1,0 +1,33 @@
+import ipaddress
+from math import exp
+from elastalert.enhancements import BaseEnhancement, DropMatchException
+from elastalert import util
+
+
+class DropIntruderIOIP(BaseEnhancement):
+    # This enhancement ensures we don't alert on Intruder.IO IP's
+    # which frequently scan our Infra.
+    def process(self, match):
+        whitelisted = self.generate_trusted_ips()
+        
+        if match["source"]["ip"] in whitelisted:
+            raise DropMatchException()
+
+    def generate_trusted_ips(self):
+        all_ips = ["139.162.214.111"]
+        ranges = [
+            "35.177.219.0/26",
+            "3.9.159.128/25",
+            "18.168.180.128/25",
+            "18.168.224.128/25",
+            "54.93.254.128/26",
+            "18.194.95.64/26",
+            "3.124.123.128/25",
+            "3.67.7.128/25",
+            "203.12.218.0/24",
+        ]
+
+        for range in ranges:
+            expanded = [str(ip) for ip in ipaddress.IPv4Address(range)]
+            all_ips.extend(expanded)
+        return all_ips


### PR DESCRIPTION
This will check if the matches `source.ip` exists within the whitelisted IP's provided by Intruder.IO [here](https://help.intruder.io/en/articles/1635683-what-ips-do-i-need-to-whitelist). If it does, it will drop the match and not alert.